### PR TITLE
Add GPose toggle

### DIFF
--- a/Tilted/CameraTilter.cs
+++ b/Tilted/CameraTilter.cs
@@ -32,24 +32,31 @@ namespace Tilted
 
     public void OnUpdate(IFramework framework)
     {
-      if (configuration.MasterEnable)
+      if (!configuration.MasterEnable)
       {
-        UpdateIsZoomed();
+        return;
+      }
 
-        if (EvaluateTriggersAndSetIsEnabled())
+      if (FFXIVClientStructs.FFXIV.Client.Game.GameMain.IsInGPose() && !configuration.EnableInGpose)
+      {
+        return;
+      }
+
+      UpdateIsZoomed();
+
+      if (EvaluateTriggersAndSetIsEnabled())
+      {
+        if (configuration.EnableCameraDistanceTweaking && !configuration.EnableZoomed)
         {
-          if (configuration.EnableCameraDistanceTweaking && !configuration.EnableZoomed)
-          {
-            TweakCameraDistance();
-          }
+          TweakCameraDistance();
         }
+      }
 
-        UpdateCombatTimeoutTimer(framework);
+      UpdateCombatTimeoutTimer(framework);
 
-        if (configuration.EnableTweakingCameraTilt)
-        {
-          TweakCameraTilt(framework);
-        }
+      if (configuration.EnableTweakingCameraTilt)
+      {
+        TweakCameraTilt(framework);
       }
     }
 

--- a/Tilted/Tilted.csproj
+++ b/Tilted/Tilted.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Authors>Meoiswa</Authors>
     <Company></Company>
-    <Version>3.3.0.1</Version>
-    <Description>Automatic Camera Adjustements</Description>
+    <Version>3.3.0.2</Version>
+    <Description>Automatic Camera Adjustments</Description>
     <Copyright></Copyright>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/Tilted/Tilted.csproj
+++ b/Tilted/Tilted.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Meoiswa</Authors>
     <Company></Company>
-    <Version>3.3.0.2</Version>
+    <Version>3.4.0.0</Version>
     <Description>Automatic Camera Adjustments</Description>
     <Copyright></Copyright>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Tilted/TiltedUI.cs
+++ b/Tilted/TiltedUI.cs
@@ -47,6 +47,12 @@ namespace Tilted
         configuration.MasterEnable = enabled;
         configuration.Save();
       }
+      var enabledInGpose = configuration.EnableInGpose;
+      if (ImGui.Checkbox("Enable in Gpose", ref enabledInGpose))
+      {
+        configuration.EnableInGpose = enabledInGpose;
+        configuration.Save();
+      }
     }
 
     private void DrawCheckbox(string label, string key, Func<bool> getter, Action<bool> setter)

--- a/Tilted/configuration/ConfigurationMKII.cs
+++ b/Tilted/configuration/ConfigurationMKII.cs
@@ -10,6 +10,7 @@ namespace Tilted
     public bool IsVisible { get; set; } = true;
 
     public bool MasterEnable { get; set; } = true;
+    public bool EnableInGpose { get; set; } = false;
     public bool EnableInDuty { get; set; } = false;
     public bool EnableInCombat { get; set; } = false;
     public bool EnableUnsheathed { get; set; } = false;


### PR DESCRIPTION
Adds a toggle so that Tilted can optionally disable itself for camera controls while in GPose. `EnableInGpose` is `false` by default.